### PR TITLE
feat: enhance ZK proof dashboard UI and functionality

### DIFF
--- a/app/api/google-forms/route.ts
+++ b/app/api/google-forms/route.ts
@@ -326,6 +326,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
       status: formStatus,
       proveTime: formProveTime,
       transactionHash: formTransactionHash,
+      hardwareInfo: 'N/A',
     };
     
     // Try to process zip file for additional proof data (if available)
@@ -367,6 +368,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
               status: formStatus, // Use form status from Google Sheets
               proveTime: formProveTime || '00:05:30',
               transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+              hardwareInfo: 'Mock Hardware Info',
             };
           } else {
             const accessToken = await generateServiceAccountToken(serviceAccountEmail, privateKey);
@@ -420,6 +422,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
                     status: formStatus, // Use form status from Google Sheets, not validation result
                     proveTime: zipData.proveTime || formProveTime,
                     transactionHash: zipData.proofData?.transactionHash || formTransactionHash,
+                    hardwareInfo: zipData.hardwareInfo || 'N/A',
                   };
                   
                   console.log('✅ Using REAL zip data:', zipProcessedData);
@@ -432,6 +435,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
                     status: formStatus, // Use form status from Google Sheets
                     proveTime: formProveTime || '00:05:30',
                     transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+                    hardwareInfo: 'Mock Hardware Info',
                   };
                 }
               } else {
@@ -442,6 +446,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
                   status: formStatus, // Use form status from Google Sheets
                   proveTime: formProveTime || '00:05:30',
                   transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+                  hardwareInfo: 'Mock Hardware Info',
                 };
               }
             } else {
@@ -454,6 +459,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
                 status: formStatus, // Use form status from Google Sheets
                 proveTime: formProveTime || '00:05:30',
                 transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+                hardwareInfo: 'Mock Hardware Info',
               };
             }
           }
@@ -465,6 +471,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
             status: formStatus, // Use form status from Google Sheets
             proveTime: formProveTime || '00:05:30',
             transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+            hardwareInfo: 'Mock Hardware Info',
           };
         }
       } catch (zipError: unknown) {
@@ -479,6 +486,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
           status: formStatus, // Use form status from Google Sheets
           proveTime: formProveTime || '00:05:30',
           transactionHash: formTransactionHash || `0x${Math.random().toString(16).substr(2, 64)}`,
+          hardwareInfo: 'Mock Hardware Info',
         };
       }
     }
@@ -494,6 +502,7 @@ async function processFormSubmission(submission: GoogleFormSubmission) {
       proveTime: zipProcessedData.proveTime,
       submissionTime: submission.timestamp,
       zipFileUrl: submission.zipFileUrl,
+      hardwareInfo: zipProcessedData.hardwareInfo,
       proofData: {
         transactionHash: zipProcessedData.transactionHash,
         proofHash: zipProcessedData.hash, // Store proof hash separately

--- a/components/ProofDesktop.tsx
+++ b/components/ProofDesktop.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-import { trimText, copyToClipboard } from "@/utils/text";
+import { trimText, copyToClipboard, formatProvingTime } from "@/utils/text";
 import {
   ProofCardProps,
   proofData,
@@ -40,6 +40,7 @@ const ProofCard: React.FC<ProofCardProps> = ({
   proofHash,
   status,
   proveTime,
+  hardwareInfo,
 }) => {
   const handleCopyAddress = () => {
     copyToClipboard(submitterAddress, () => {
@@ -64,7 +65,16 @@ const ProofCard: React.FC<ProofCardProps> = ({
   // Use trimText function for display
   const displayAddress = trimText(submitterAddress);
   const displayHash = trimText(hash);
-  const displayProofHash = proofHash ? `${proofHash.slice(0, 20)}...${proofHash.slice(-8)}` : 'N/A';
+  const displayProofHash = proofHash ? trimText(proofHash) : 'N/A';
+  const formattedProveTime = formatProvingTime(proveTime);
+  const displayHardwareInfo = hardwareInfo || 'N/A';
+  const getShortHardwareInfo = (info: string) => {
+    if (!info || info === 'N/A') return 'N/A';
+    // Extract just the chip name (e.g., "Apple M1 Max" from "Apple M1 Max, 10 cores, 32GB RAM, macOS")
+    const chipMatch = info.match(/^([^,]+)/);
+    return chipMatch ? chipMatch[1].trim() : info;
+  };
+  const shortHardwareInfo = getShortHardwareInfo(displayHardwareInfo);
   return (
     <div
       style={{
@@ -79,7 +89,7 @@ const ProofCard: React.FC<ProofCardProps> = ({
         position: "relative",
       }}
     >
-      {/* Top Row - 3 fields */}
+      {/* Row 1 - Proof Hash and Status */}
       <div style={{ display: "flex", gap: "16px", width: "100%" }}>
         {/* Proof Hash */}
         <div
@@ -117,25 +127,68 @@ const ProofCard: React.FC<ProofCardProps> = ({
             >
               {displayProofHash}
             </div>
-            {proofHash && (
-              <div
-                style={{
-                  width: "22px",
-                  height: "22px",
-                  aspectRatio: "1/1",
-                  cursor: "pointer",
-                }}
-                onClick={handleCopyProofHash}
-              >
-                <CopyIcon />
-              </div>
-            )}
+            <div
+              style={{
+                width: "22px",
+                height: "22px",
+                aspectRatio: "1/1",
+                cursor: "pointer",
+              }}
+              onClick={handleCopyProofHash}
+            >
+              <CopyIcon />
+            </div>
+          </div>
+        </div>
+
+        {/* Status */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: "8px",
+            flex: "1 0 0",
+          }}
+        >
+          <div
+            style={{
+              color: "#619EC9",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 300,
+              lineHeight: "normal",
+            }}
+          >
+            Status
+          </div>
+          <div
+            style={{
+              display: "inline-flex",
+              padding: "4px 8px",
+              justifyContent: "center",
+              alignItems: "center",
+              gap: "10px",
+              borderRadius: "4px",
+              border: status === "1" ? "1px solid #66EAFF" : "1px solid #F5A623",
+              background: status === "1" ? "#66EAFF" : "#F5A623",
+              color: "#000",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 600,
+              lineHeight: "normal",
+            }}
+          >
+            {getStatusDisplay(status)}
           </div>
         </div>
 
       </div>
 
-      {/* Second Row - 2 fields */}
+      {/* Row 2 - Transaction Hash and Submitter Address */}
       <div style={{ display: "flex", gap: "16px", width: "100%" }}>
         {/* Transaction Hash */}
         <div
@@ -184,84 +237,6 @@ const ProofCard: React.FC<ProofCardProps> = ({
             >
               <CopyIcon />
             </div>
-          </div>
-        </div>
-
-        {/* Status */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "flex-start",
-            gap: "8px",
-            flex: "1 0 0",
-          }}
-        >
-          <div
-            style={{
-              color: "#619EC9",
-              fontFamily: "IBM Plex Mono",
-              fontSize: "14px",
-              fontStyle: "normal",
-              fontWeight: 300,
-              lineHeight: "normal",
-            }}
-          >
-            Status
-          </div>
-          <div
-            style={{
-              color: getStatusDisplay(status) === "Verified" ? "#10B981" : 
-                     getStatusDisplay(status) === "Rejected" ? "#EF4444" : "#F59E0B",
-              fontFamily: "IBM Plex Mono",
-              fontSize: "16px",
-              fontStyle: "normal",
-              fontWeight: 500,
-              lineHeight: "normal",
-            }}
-          >
-            {getStatusDisplay(status)}
-          </div>
-        </div>
-      </div>
-
-      {/* Second Row - 2 fields */}
-      <div style={{ display: "flex", gap: "16px", width: "100%" }}>
-        {/* Prove Time */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "flex-start",
-            gap: "8px",
-            flex: "1 0 0",
-          }}
-        >
-          <div
-            style={{
-              color: "#619EC9",
-              fontFamily: "IBM Plex Mono",
-              fontSize: "14px",
-              fontStyle: "normal",
-              fontWeight: 300,
-              lineHeight: "normal",
-            }}
-          >
-            Prove Time
-          </div>
-          <div
-            style={{
-              color: "#66EAFF",
-              fontFamily: "IBM Plex Mono",
-              fontSize: "18px",
-              fontStyle: "normal",
-              fontWeight: 500,
-              lineHeight: "normal",
-            }}
-          >
-            {proveTime}
           </div>
         </div>
 
@@ -314,6 +289,90 @@ const ProofCard: React.FC<ProofCardProps> = ({
             </div>
           </div>
         </div>
+
+      </div>
+
+      {/* Row 3 - Prove Time and Hardware Info */}
+      <div style={{ display: "flex", gap: "16px", width: "100%" }}>
+        {/* Prove Time */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: "8px",
+            flex: "1 0 0",
+          }}
+        >
+          <div
+            style={{
+              color: "#619EC9",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 300,
+              lineHeight: "normal",
+            }}
+          >
+            Prove Time
+          </div>
+          <div
+            style={{
+              color: "#66EAFF",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "18px",
+              fontStyle: "normal",
+              fontWeight: 500,
+              lineHeight: "normal",
+            }}
+          >
+            {formattedProveTime}
+          </div>
+        </div>
+
+        {/* Hardware Info */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: "8px",
+            flex: "1 0 0",
+          }}
+        >
+          <div
+            style={{
+              color: "#619EC9",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 300,
+              lineHeight: "normal",
+            }}
+          >
+            Hardware Info
+          </div>
+          <div
+            style={{
+              color: "#FFF",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "16px",
+              fontStyle: "normal",
+              fontWeight: 500,
+              lineHeight: "normal",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              maxWidth: "100%",
+              cursor: "help",
+            }}
+            title={displayHardwareInfo}
+          >
+            {shortHardwareInfo}
+          </div>
+        </div>
       </div>
 
     </div>
@@ -341,6 +400,7 @@ const ProofDesktop = () => {
     proveTime: proof.proveTime,
     submissionTime: proof.submissionTime,
     id: proof.id,
+    hardwareInfo: proof.hardwareInfo,
     proofData: proof.proofData,
   }));
 
@@ -358,8 +418,9 @@ const ProofDesktop = () => {
         style={{
           display: "flex",
           width: "100%",
-          minHeight: "600px",
+          height: "105vh",
           padding: "24px",
+          paddingBottom: "40px",
           flexDirection: "column",
           alignItems: "center",
           gap: "16px",
@@ -400,6 +461,7 @@ const ProofDesktop = () => {
                   proveTime={proof.proveTime}
                   submissionTime={proof.submissionTime}
                   id={proof.id}
+                  hardwareInfo={proof.hardwareInfo}
                   proofData={proof.proofData}
                 />
               ))
@@ -412,6 +474,7 @@ const ProofDesktop = () => {
                   proofHash={proof.proofHash}
                   status={proof.status}
                   proveTime={proof.proveTime}
+                  hardwareInfo={proof.hardwareInfo}
                 />
               ))
             )

--- a/components/ProofMobile.tsx
+++ b/components/ProofMobile.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { trimText, copyToClipboard } from "@/utils/text";
+import { trimText, copyToClipboard, formatProvingTime } from "@/utils/text";
 import {
   ProofCardProps,
   // proofData,
@@ -39,6 +39,7 @@ const ProofCard: React.FC<ProofCardProps> = ({
   proofHash,
   status,
   proveTime,
+  hardwareInfo,
 }) => {
   const handleCopyAddress = () => {
     copyToClipboard(submitterAddress, () => {
@@ -63,7 +64,16 @@ const ProofCard: React.FC<ProofCardProps> = ({
   // Use trimText function for display
   const displayAddress = trimText(submitterAddress);
   const displayHash = trimText(hash);
-  const displayProofHash = proofHash ? `${proofHash.slice(0, 20)}...${proofHash.slice(-8)}` : 'N/A';
+  const displayProofHash = proofHash ? trimText(proofHash) : 'N/A';
+  const formattedProveTime = formatProvingTime(proveTime);
+  const displayHardwareInfo = hardwareInfo || 'N/A';
+  const getShortHardwareInfo = (info: string) => {
+    if (!info || info === 'N/A') return 'N/A';
+    // Extract just the chip name (e.g., "Apple M1 Max" from "Apple M1 Max, 10 cores, 32GB RAM, macOS")
+    const chipMatch = info.match(/^([^,]+)/);
+    return chipMatch ? chipMatch[1].trim() : info;
+  };
+  const shortHardwareInfo = getShortHardwareInfo(displayHardwareInfo);
   return (
     <div
       style={{
@@ -78,7 +88,7 @@ const ProofCard: React.FC<ProofCardProps> = ({
         position: "relative",
       }}
     >
-      {/* Top Row - 3 fields */}
+      {/* Top Row - Submitter Address and Status */}
       <div
         style={{
           display: "flex",
@@ -86,57 +96,6 @@ const ProofCard: React.FC<ProofCardProps> = ({
           width: "100%",
         }}
       >
-        {/* Proof Hash */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "flex-start",
-            gap: "8px",
-          }}
-        >
-          <div
-            style={{
-              color: "#619EC9",
-              fontFamily: "IBM Plex Mono",
-              fontSize: "14px",
-              fontStyle: "normal",
-              fontWeight: 300,
-              lineHeight: "normal",
-            }}
-          >
-            Proof Hash
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
-            <div
-              style={{
-                color: "#FFF",
-                fontFamily: "IBM Plex Mono",
-                fontSize: "16px",
-                fontStyle: "normal",
-                fontWeight: 500,
-                lineHeight: "normal",
-              }}
-            >
-              {displayProofHash}
-            </div>
-            {proofHash && (
-              <div
-                style={{
-                  width: "22px",
-                  height: "22px",
-                  aspectRatio: "1/1",
-                  cursor: "pointer",
-                }}
-                onClick={handleCopyProofHash}
-              >
-                <CopyIcon />
-              </div>
-            )}
-          </div>
-        </div>
-
         {/* Submitter Address */}
         <div
           style={{
@@ -327,7 +286,7 @@ const ProofCard: React.FC<ProofCardProps> = ({
               textAlign: "left",
             }}
           >
-            {proveTime}
+            {formattedProveTime}
           </div>
         </div>
 
@@ -381,6 +340,110 @@ const ProofCard: React.FC<ProofCardProps> = ({
         </div>
       </div>
 
+      {/* Additional Row - Proof Hash and Hardware Info */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          width: "100%",
+          marginTop: "16px",
+        }}
+      >
+        {/* Proof Hash */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: "8px",
+            flex: "1",
+            marginRight: "16px",
+          }}
+        >
+          <div
+            style={{
+              color: "#619EC9",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 300,
+              lineHeight: "normal",
+            }}
+          >
+            Proof Hash
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+            <div
+              style={{
+                color: "#FFF",
+                fontFamily: "IBM Plex Mono",
+                fontSize: "16px",
+                fontStyle: "normal",
+                fontWeight: 500,
+                lineHeight: "normal",
+              }}
+            >
+              {displayProofHash}
+            </div>
+            <div
+              style={{
+                width: "22px",
+                height: "22px",
+                aspectRatio: "1/1",
+                cursor: "pointer",
+              }}
+              onClick={handleCopyProofHash}
+            >
+              <CopyIcon />
+            </div>
+          </div>
+        </div>
+
+        {/* Hardware Info */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            alignItems: "flex-start",
+            gap: "8px",
+            flex: "1",
+          }}
+        >
+          <div
+            style={{
+              color: "#619EC9",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 300,
+              lineHeight: "normal",
+            }}
+          >
+            Hardware Info
+          </div>
+          <div
+            style={{
+              color: "#FFF",
+              fontFamily: "IBM Plex Mono",
+              fontSize: "14px",
+              fontStyle: "normal",
+              fontWeight: 500,
+              lineHeight: "normal",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              maxWidth: "100%",
+              cursor: "help",
+            }}
+            title={displayHardwareInfo}
+          >
+            {shortHardwareInfo}
+          </div>
+        </div>
+      </div>
+
     </div>
   );
 };
@@ -406,6 +469,7 @@ const ProofMobile = () => {
     proveTime: proof.proveTime,
     submissionTime: proof.submissionTime,
     id: proof.id,
+    hardwareInfo: proof.hardwareInfo,
     proofData: proof.proofData,
   }));
 
@@ -432,6 +496,11 @@ const ProofMobile = () => {
           flexDirection: "column",
           gap: "12px",
           width: "100%",
+          height: "calc(100vh - 40px)",
+          overflowY: "auto",
+          padding: "16px 4px",
+          paddingBottom: "40px",
+          marginBottom: "32px",
         }}
       >
         {loading && (
@@ -456,6 +525,7 @@ const ProofMobile = () => {
                 proofHash={proof.proofHash}
                 status={proof.status}
                 proveTime={proof.proveTime}
+                hardwareInfo={proof.hardwareInfo}
               />
             ))
           ) : (
@@ -482,6 +552,7 @@ const ProofMobile = () => {
                     hash={proof.hash}
                     status={proof.status}
                     proveTime={proof.proveTime}
+                    hardwareInfo={proof.hardwareInfo}
                   />
                 </div>
                 {/* Overlay */}

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,7 +1,7 @@
 export const LINKS = {
   X: "https://x.com/tokamak_network",
   YOUTUBE: "https://www.youtube.com/@TokamakZKPWorld",
-  DISCORD: "https://discord.gg/6NaZnw3b",
+  DISCORD: "https://discord.gg/BgtSfggv",
   SUBMIT_PROOF:
     "https://forms.gle/BocX6o4GZRcmr3fF7",
 };

--- a/data/proofData.ts
+++ b/data/proofData.ts
@@ -7,6 +7,7 @@ export interface ProofCardProps {
   proveTime: string;
   submissionTime?: string;
   id?: string;
+  hardwareInfo?: string;
   proofData?: {
     publicSignals?: any;
     proof?: any;
@@ -23,6 +24,7 @@ export interface ProofSubmission {
   proveTime: string;
   submissionTime: string;
   zipFileUrl?: string;
+  hardwareInfo?: string;
   proofData?: {
     publicSignals?: any;
     proof?: any;

--- a/hooks/useProofs.ts
+++ b/hooks/useProofs.ts
@@ -8,6 +8,7 @@ export interface ProofSubmission {
   proveTime: string;
   submissionTime: string;
   zipFileUrl?: string;
+  hardwareInfo?: string;
   proofData?: {
     publicSignals?: any;
     proof?: any;

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -22,6 +22,38 @@ export const trimText = (
 };
 
 /**
+ * Format proving time from MM:SS:00 to "xx mins and xx secs"
+ * @param {string} timeString - Time in MM:SS:00 format (where first part is minutes, second is seconds)
+ * @returns {string} Formatted time string
+ */
+export const formatProvingTime = (timeString: string): string => {
+  if (!timeString || timeString === '00:00:00') {
+    return 'N/A';
+  }
+
+  // Handle different time formats
+  const timeParts = timeString.split(':');
+  
+  if (timeParts.length === 3) {
+    // MM:SS:00 format (minutes:seconds:ignored)
+    const minutes = parseInt(timeParts[0]);
+    const seconds = parseInt(timeParts[1]);
+    // Third part is ignored (always 00)
+    
+    if (minutes === 0) {
+      return `${seconds} secs`;
+    } else if (seconds === 0) {
+      return `${minutes} mins`;
+    } else {
+      return `${minutes} mins and ${seconds} secs`;
+    }
+  }
+  
+  // If format is unexpected, return as-is
+  return timeString;
+};
+
+/**
  * Copy text to clipboard
  * @param {string} text - Text to copy
  * @param {() => void} onSuccess - Callback function on successful copy


### PR DESCRIPTION
- Reorganize proof card layout to 3-row structure:
  * Row 1: Proof Hash + Status
  * Row 2: Transaction Hash + Submitter Address
  * Row 3: Prove Time + Hardware Info
- Add hardware info extraction from benchmark.json files
- Implement compact hardware display (chip name only, full details on hover)
- Fix proving time format calculation (MM:SS:00 -> mins and secs)
- Increase dashboard height for better content visibility
- Add proper scrolling and bottom margins
- Update Discord link to new invitation URL
- Improve mobile responsiveness and layout consistency
- Add hardwareInfo field to all proof interfaces and components