### PR TITLE
fix: update mobile schedule dates from Sep 11-15 to Sep 16-30

### DIFF
--- a/components/hero/QuestSection.tsx
+++ b/components/hero/QuestSection.tsx
@@ -661,13 +661,13 @@ const Quest = () => {
               Event Period:
               <br className="max-500:block hidden" />
               <span style={{ fontWeight: "700" }}>
-                Sep 11 (Thu) – Sep 15 (Mon), 12PM KST
+                Sep 16 (Mon) – Sep 30 (Mon), 12AM-11:59PM KST
               </span>
             </div>
             <div style={{ marginTop: "8px" }}>
               <span style={{ fontWeight: "700" }}>Reward Distribution:</span>
               <br className="max-500:block hidden" />
-              Sep 18 (Thu)
+              Oct 3 (Thu)
             </div>
           </div>
         </MobileCard>


### PR DESCRIPTION
…rrect reward distribution date

- Updated mobile Schedule section to match desktop version
- Changed event period from 'Sep 11 (Thu) – Sep 15 (Mon), 12PM KST' to 'Sep 16 (Mon) – Sep 30 (Mon), 12AM-11:59PM KST'
- Updated reward distribution date from 'Sep 18 (Thu)' to 'Oct 3 (Thu)'
- Ensures consistency between mobile and desktop responsive designs