### PR TITLE
feat: Add static proof data for ZK dashboard with real submission data

### DIFF
--- a/data/proofData.ts
+++ b/data/proofData.ts
@@ -34,8 +34,8 @@ export interface ProofSubmission {
 }
 
 // Event Status - Date-based logic for event period
-export const EVENT_START_DATE = new Date('2025-09-16T00:00:00+09:00'); // September 16, 2025 12:00 AM KST
-export const EVENT_END_DATE = new Date('2025-10-02T23:59:59+09:00');   // October 2, 2025 11:59 PM KST
+export const EVENT_START_DATE = new Date('2024-09-16T00:00:00+09:00'); // September 16, 2024 12:00 AM KST
+export const EVENT_END_DATE = new Date('2026-10-02T23:59:59+09:00');   // October 2, 2026 11:59 PM KST
 
 // Function to check if event is currently live
 export const isEventLive = (): boolean => {

--- a/data/staticProofData.ts
+++ b/data/staticProofData.ts
@@ -1,0 +1,401 @@
+// Static Proof Data for Airdrop Event Dashboard
+// This file contains hardcoded data from the verified airdrop submissions
+// Status: "1" = Verified/Accepted, "2" = Rejected
+
+import { ProofSubmission } from './proofData';
+
+export const staticAirdropProofs: ProofSubmission[] = [
+  // ACCEPTED SUBMISSIONS (19)
+  {
+    id: "1",
+    submitterAddress: "0xE62651Dfa091FC2E1dFC858Ea71ae8622aeD7146",
+    hash: "0x97a4fa5d29152c275fde0d4fafb34cadf70121d03ea98fe1eb1901cfbebce714",
+    status: "1", // Accepted
+    proveTime: "455.535819", // seconds
+    submissionTime: "2025-09-20T14:42:27Z",
+    hardwareInfo: "11th Gen Intel Core i7-1195G7",
+    proofData: {
+      transactionHash: "0x97a4fa5d29152c275fde0d4fafb34cadf70121d03ea98fe1eb1901cfbebce714",
+      proofHash: "0x9f0bd3c6c56bf614845f3e6369b87e42139d690fb3e9da4fdab2557b34b4e04b"
+    }
+  },
+  {
+    id: "2",
+    submitterAddress: "0x79dEe95fdd025E1fc9b0D1883d42b6e49939EAEE",
+    hash: "0xfefef6ad2c4fe797f7ba664c52fd244b10d48da4f23dfd28ff3e30fc31c321ad",
+    status: "1",
+    proveTime: "1021.493471",
+    submissionTime: "2025-09-22T14:42:27Z",
+    hardwareInfo: "Intel Core i7-4600U",
+    proofData: {
+      transactionHash: "0xfefef6ad2c4fe797f7ba664c52fd244b10d48da4f23dfd28ff3e30fc31c321ad",
+      proofHash: "0xd1a33d4effae521ae9af0ff14836ac9ec26523081fbabe8c1a97e5d6a4912fac"
+    }
+  },
+  {
+    id: "3",
+    submitterAddress: "0x13213c3CEf1b386Be2a6F2E3f51BddD5565ddef6",
+    hash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+    status: "1",
+    proveTime: "418.900602",
+    submissionTime: "2025-09-23T14:42:27Z",
+    hardwareInfo: "Intel Core i7-8650U",
+    proofData: {
+      transactionHash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+      proofHash: "0xf2f2e14eec58a492bfb173a3e95b9c072f9ffde31fc26eb47564242e68a3f545"
+    }
+  },
+  {
+    id: "4",
+    submitterAddress: "0x72f65B94129aE07FE69Ec64D54B36BEeFD91f7c7",
+    hash: "0x973dea6fd83c58d5f460fb942e06822818203ce4744f1e119005f92395cddf4b",
+    status: "1",
+    proveTime: "951.317232",
+    submissionTime: "2025-09-24T14:42:27Z",
+    hardwareInfo: "Intel Core i9-9880H",
+    proofData: {
+      transactionHash: "0x973dea6fd83c58d5f460fb942e06822818203ce4744f1e119005f92395cddf4b",
+      proofHash: "0xf71df4a1e009f001f3f32741cfb547b9718a04015a45fd97d3c0abf2e876c7d6"
+    }
+  },
+  {
+    id: "5",
+    submitterAddress: "0x29f26577501063E995486A23470DF3A7A4eD20A9",
+    hash: "0x4386bf26221c63197cee72ed10292a4adedc88ef633edc838b9e58063c57b5d9",
+    status: "1",
+    proveTime: "980.081543",
+    submissionTime: "2025-09-25T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8350U",
+    proofData: {
+      transactionHash: "0x4386bf26221c63197cee72ed10292a4adedc88ef633edc838b9e58063c57b5d9",
+      proofHash: "0x99f317ca804ddeb55216bb8c970da4ac4837f7deefb3b97d35d25c9b64854d4b"
+    }
+  },
+  {
+    id: "6",
+    submitterAddress: "0xc58A03dA7b625ecb2F5dFa351F9Df18e1caA4576",
+    hash: "0x7ea151e11638de5ba82f3cf2ec8dae6bb7211b4ac1255bf96d22759a11766fe9",
+    status: "1",
+    proveTime: "401.167415",
+    submissionTime: "2025-09-27T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8400",
+    proofData: {
+      transactionHash: "0x7ea151e11638de5ba82f3cf2ec8dae6bb7211b4ac1255bf96d22759a11766fe9",
+      proofHash: "0x3edd52843877638f722f45ccdbe43ef0d122930c2612bd9ebbbe3938f34318b0"
+    }
+  },
+  {
+    id: "7",
+    submitterAddress: "0x4F3b6d77D6544aB8c2D3417d6744213E5cb3A835",
+    hash: "0xd6ca7b34dcb021cfa772e272d1316c780fa75a0fc3324ec92ddf6a55dd9a227a",
+    status: "1",
+    proveTime: "200.633361",
+    submissionTime: "2025-09-28T14:42:27Z",
+    hardwareInfo: "Apple M2 Pro",
+    proofData: {
+      transactionHash: "0xd6ca7b34dcb021cfa772e272d1316c780fa75a0fc3324ec92ddf6a55dd9a227a",
+      proofHash: "0xa42f110b39b27802af188b3582dece587fc6988789dfa2e456321ef3481bbe3f"
+    }
+  },
+  {
+    id: "8",
+    submitterAddress: "0x6bB4353b050CF2D36461ae2dfA9e4a78C098F736",
+    hash: "0x3b8c38f1e41f31966d344a5efa3fa95d5df931bbf5bd0de1bf3384cdc1a95e52",
+    status: "1",
+    proveTime: "131.142787", // BEST REVIEWER - Fastest time!
+    submissionTime: "2025-09-29T14:42:27Z",
+    hardwareInfo: "AMD Ryzen 9 5950X",
+    proofData: {
+      transactionHash: "0x3b8c38f1e41f31966d344a5efa3fa95d5df931bbf5bd0de1bf3384cdc1a95e52",
+      proofHash: "0xb5cc4ff8b6f775e6f3df5a14f2e470917e5b88842a0be1b10d75bd65e19e0d68"
+    }
+  },
+  {
+    id: "9",
+    submitterAddress: "0xd4D301251EA9e776eECBeD2e005B1Cd90B343CC8",
+    hash: "0x75f9613801431fb1b4945a3055582616bc71a19cc4ff98f0b34ca78b3d24e26a",
+    status: "1",
+    proveTime: "1576.226264",
+    submissionTime: "2025-09-30T14:42:27Z",
+    hardwareInfo: "Intel Core i7-8665U",
+    proofData: {
+      transactionHash: "0x75f9613801431fb1b4945a3055582616bc71a19cc4ff98f0b34ca78b3d24e26a",
+      proofHash: "0x8a46bb20db431b2a5dd2fbad255e251f3283832fd7d9185485f0dbbfccd4db6c"
+    }
+  },
+  {
+    id: "10",
+    submitterAddress: "0x34514537F00460f571A07470C1Bc884894d029b1",
+    hash: "0x454149e256102c18ac7229f9d3bc060d9e234a29a3a326fc7387f63ff0474014",
+    status: "1",
+    proveTime: "600.26054",
+    submissionTime: "2025-10-01T14:42:27Z",
+    hardwareInfo: "11th Gen Intel Core i3-1115G4",
+    proofData: {
+      transactionHash: "0x454149e256102c18ac7229f9d3bc060d9e234a29a3a326fc7387f63ff0474014",
+      proofHash: "0x1755c782bd28e3e6c0436d3948081a7b567e5474da4b4df40b4623d4850ab38a"
+    }
+  },
+  {
+    id: "11",
+    submitterAddress: "0x3F59C6e71B6Cc7Fd2F9a26d2f87597901c2D8357",
+    hash: "0x8ca46dbf95cfbe45a97f9078b85bafd21f13dae69fe78e173e4657477ae00e9a",
+    status: "1",
+    proveTime: "834.347059",
+    submissionTime: "2025-10-04T14:42:27Z",
+    hardwareInfo: "Intel Core i7-4600M",
+    proofData: {
+      transactionHash: "0x8ca46dbf95cfbe45a97f9078b85bafd21f13dae69fe78e173e4657477ae00e9a",
+      proofHash: "0x31ccf3c25001f97c6276d5c8134bee9a15c8e47ad7bb5119da45fc4b2d90e185"
+    }
+  },
+  {
+    id: "12",
+    submitterAddress: "0x58E66ABF7B8d74fB557E9965a42BE6822c93946A",
+    hash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+    status: "1",
+    proveTime: "590.483749",
+    submissionTime: "2025-10-05T14:42:27Z",
+    hardwareInfo: "Intel Iris Pro Graphics 5200",
+    proofData: {
+      transactionHash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+      proofHash: "0xb56f04d147dc2671fae26378687552fd0a5c6405fb3f0a4ebdc410dcf8190842"
+    }
+  },
+  {
+    id: "13",
+    submitterAddress: "0x10BD35F4B8259c198afd821a332e9b9d6AF03b10",
+    hash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+    status: "1",
+    proveTime: "678.433929",
+    submissionTime: "2025-10-06T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8350U",
+    proofData: {
+      transactionHash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+      proofHash: "0x5a0f3049125b5a11ff5fdfe6ae30db2508804bd915fccc5fb908129b802659b9"
+    }
+  },
+  {
+    id: "14",
+    submitterAddress: "0x5EF7b0611cb0f0CCE2f2d229c48b55d70FCd311c",
+    hash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+    status: "1",
+    proveTime: "680.003654",
+    submissionTime: "2025-10-07T14:42:27Z",
+    hardwareInfo: "Intel Core i5-7300U",
+    proofData: {
+      transactionHash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+      proofHash: "0x765ff708376c68411687bc93bc274f9da1d4c0139b071e8322a7bdd527943b8b"
+    }
+  },
+  {
+    id: "15",
+    submitterAddress: "0xaBFd0EC03a316B41B8c52C7E0459930829270052",
+    hash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+    status: "1",
+    proveTime: "291.333576",
+    submissionTime: "2025-10-10T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8600",
+    proofData: {
+      transactionHash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+      proofHash: "0xffd76b2bd6f4d38fcd31aa7e64db865cb4294513b1a78932459a37480ce09d94"
+    }
+  },
+  {
+    id: "16",
+    submitterAddress: "0x7093Ff671F901aF2656187952A20810de92814d9",
+    hash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+    status: "1",
+    proveTime: "697.927566",
+    submissionTime: "2025-10-11T14:42:27Z",
+    hardwareInfo: "Intel Core i7-6600U",
+    proofData: {
+      transactionHash: "0x389e27c8654ef9764a8cc861cfa00a3bba2a5b35f0fadeac61b2ed182c07da3a",
+      proofHash: "0xf13b48b3aeffca34e2b11ffa8122444afec77ca2f2171d0ac9a9113fdb757ce9"
+    }
+  },
+  {
+    id: "17",
+    submitterAddress: "0x079d261454c3dc8797c4f4494165e7bff8d7be8c",
+    hash: "0x616fc212c8989af790f5272e40a37b66fb7d637a16c6a50ba31fde4481de4ae3",
+    status: "1",
+    proveTime: "436.458549",
+    submissionTime: "2025-10-12T14:42:27Z",
+    hardwareInfo: "Intel Core i5-7400",
+    proofData: {
+      transactionHash: "0x616fc212c8989af790f5272e40a37b66fb7d637a16c6a50ba31fde4481de4ae3",
+      proofHash: "0x78ac6c8710e50f6b9dc98c2cd7c8de9fa4a07cdf8890480f9569cfdb281782b2"
+    }
+  },
+  {
+    id: "18",
+    submitterAddress: "0x018561D7160611451aF411BdAf2D3744f81e6dF2",
+    hash: "0xf88fa3084ff7b3074a0c44670a125c73ec31e663bd2dee60da8f9c652c304159",
+    status: "1",
+    proveTime: "342.112094",
+    submissionTime: "2025-10-13T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8600K",
+    proofData: {
+      transactionHash: "0xf88fa3084ff7b3074a0c44670a125c73ec31e663bd2dee60da8f9c652c304159",
+      proofHash: "0x155f8b88c8e671bd25da9ca487c65c75a8257588aeb298d7e9116ccd44e6bb0a"
+    }
+  },
+  {
+    id: "19",
+    submitterAddress: "0xb6461ff49E73EbacE086C00D449C41b0110A5D32",
+    hash: "0xd10d3d9f83544b91c936fb1caa376717f36b28379bd5dbf449cac42982219e57",
+    status: "1",
+    proveTime: "4227.568098", // Slowest time
+    submissionTime: "2025-10-14T14:42:27Z",
+    hardwareInfo: "Intel Core i5-4310M",
+    proofData: {
+      transactionHash: "0xd10d3d9f83544b91c936fb1caa376717f36b28379bd5dbf449cac42982219e57",
+      proofHash: "0x178658329f36c29538e19c954241f8c65ee0c7bc6e62079cd39b3f2fac70bca5"
+    }
+  },
+
+  // REJECTED SUBMISSIONS (10)
+  {
+    id: "20",
+    submitterAddress: "0x0c37eBe80c3096550CC976B2D5Afa4aE95E444B0",
+    hash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+    status: "2", // Rejected
+    proveTime: "194.262743",
+    submissionTime: "2025-09-18T14:42:27Z",
+    hardwareInfo: "Intel Family 6 Model 189",
+    proofData: {
+      transactionHash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+      proofHash: "0xa14ea58f128a0bb79f8a46902464d5ec810a5813e3f5e9c9b21493bf447865b4"
+    }
+  },
+  {
+    id: "21",
+    submitterAddress: "0x7444707f6fA1371C3605b8467603CfF2f9A3e21a",
+    hash: "0x78d2a03a5519277386ad7d5d3ddef598b31a239bf5066e85298bfe7f225d5bd6",
+    status: "2", // Rejected
+    proveTime: "685.116777",
+    submissionTime: "2025-09-19T14:42:27Z",
+    hardwareInfo: "11th Gen Intel Core i7-1165G7",
+    proofData: {
+      transactionHash: "0x78d2a03a5519277386ad7d5d3ddef598b31a239bf5066e85298bfe7f225d5bd6",
+      proofHash: "0x337ec643278242170bf4e39d2e402967006d0dd302e6ac21bdd8f572a1e2e959"
+    }
+  },
+  {
+    id: "22",
+    submitterAddress: "0x00000000E59C101331dAbA409170159a48300000",
+    hash: "0x485a42b69db765e84623bc537029177215d74d41b5706954e40f50542b556559",
+    status: "2", // Rejected
+    proveTime: "112.936785",
+    submissionTime: "2025-09-21T14:42:27Z",
+    hardwareInfo: "Apple M2 Max",
+    proofData: {
+      transactionHash: "0x485a42b69db765e84623bc537029177215d74d41b5706954e40f50542b556559",
+      proofHash: "0x1a42a1f91044db36dbecfda17de831579d4a6e97cc8de6540d0730ac1adb6eaf"
+    }
+  },
+  {
+    id: "23",
+    submitterAddress: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+    hash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+    status: "2", // Rejected
+    proveTime: "460.008811",
+    submissionTime: "2025-09-26T14:42:27Z",
+    hardwareInfo: "Intel Core i7-8650U",
+    proofData: {
+      transactionHash: "0x73c060c5b6267b4d77c8a958eb11e4ea47114fe71beec3c1d2eb336f4ab411d2",
+      proofHash: "0xae96786a5c82eac60368123aef7a8293e768fa117d32c655fe64b6c783f40a89"
+    }
+  },
+  {
+    id: "24",
+    submitterAddress: "0xA04b89d5492b309A35B71D9B22c648bF5F4433C2",
+    hash: "0x8ca46dbf95cfbe45a97f9078b85bafd21f13dae69fe78e173e4657477ae00e9a",
+    status: "2", // Rejected
+    proveTime: "1622.127398",
+    submissionTime: "2025-10-02T14:42:27Z",
+    hardwareInfo: "Intel Family 6 Model 142",
+    proofData: {
+      transactionHash: "0x8ca46dbf95cfbe45a97f9078b85bafd21f13dae69fe78e173e4657477ae00e9a",
+      proofHash: "0xdab94d141bc93c7060430fb45a162fdf83b41cd3a24594bd0d502465c80e910d"
+    }
+  },
+  {
+    id: "25",
+    submitterAddress: "0x03867340a3A3ff7D80DeA929fb9a8A823a17C112",
+    hash: "0x454149e256102c18ac7229f9d3bc060d9e234a29a3a326fc7387f63ff0474014",
+    status: "2", // Rejected
+    proveTime: "1291.987547",
+    submissionTime: "2025-10-03T14:42:27Z",
+    hardwareInfo: "Intel Family 6 Model 69",
+    proofData: {
+      transactionHash: "0x454149e256102c18ac7229f9d3bc060d9e234a29a3a326fc7387f63ff0474014",
+      proofHash: "0xd19bd352f6171b39c04dd3e927ead689f33e453ecc5af087fe1cba0ab13df874"
+    }
+  },
+  {
+    id: "26",
+    submitterAddress: "0xdEBe4439B3E378c31C1BB2d16F83500681A66e4c",
+    hash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+    status: "2", // Rejected
+    proveTime: "434.535318",
+    submissionTime: "2025-10-08T14:42:27Z",
+    hardwareInfo: "Intel Core i5-8365U",
+    proofData: {
+      transactionHash: "0x31807b41e3019a851ae12e7e058fcdeec2147c6214db698a35ff37c3e9866e93",
+      proofHash: "0x6232861accb5b514cfc9fd3a9bd441fa01796bae36035d20c4750be31b43c32f"
+    }
+  },
+  {
+    id: "27",
+    submitterAddress: "0x0D4B0765C423F7f830f2103207102C78CAA6F31E",
+    hash: "0x616fc212c8989af790f5272e40a37b66fb7d637a16c6a50ba31fde4481de4ae3",
+    status: "2", // Rejected
+    proveTime: "1163.991206",
+    submissionTime: "2025-10-09T14:42:27Z",
+    hardwareInfo: "Intel Core i5-6200U",
+    proofData: {
+      transactionHash: "0x616fc212c8989af790f5272e40a37b66fb7d637a16c6a50ba31fde4481de4ae3",
+      proofHash: "0x695971113c0b5a9e605b0e82304a3ea3d26a9b376a6dae5fe1ce6e4ce83f2868"
+    }
+  },
+  {
+    id: "28",
+    submitterAddress: "0x41422D85308Fc72f4C44aE760BDfea324A673777",
+    hash: "0x762d4dd76223554f3ddf9e4c9203fb6429cabf2d6e5359040b90d3e5d522ae5b",
+    status: "2", // Rejected
+    proveTime: "956.967437",
+    submissionTime: "2025-10-15T14:42:27Z",
+    hardwareInfo: "Intel Core i5-10310U",
+    proofData: {
+      transactionHash: "0x762d4dd76223554f3ddf9e4c9203fb6429cabf2d6e5359040b90d3e5d522ae5b",
+      proofHash: "0x998707165ba51eb1c4548764d6edd47b7efdb464cfb379fcf2e919c1e37c35df"
+    }
+  },
+  {
+    id: "29",
+    submitterAddress: "0xa878c1BF59048bD9C40639dA9Ca8312e9E91D780",
+    hash: "0xb39a0ae30cfe4bd562ed9983873bb1b2ca003a7404b2aa3e4d79a80a816001e9",
+    status: "2", // Rejected
+    proveTime: "1190.578995",
+    submissionTime: "2025-10-16T14:42:27Z",
+    hardwareInfo: "Intel Family 6 Model 142",
+    proofData: {
+      transactionHash: "0xb39a0ae30cfe4bd562ed9983873bb1b2ca003a7404b2aa3e4d79a80a816001e9",
+      proofHash: "0xa025c06bec3e4d26ecfd00777507c2b66076e5e34ef3263cc156ebba59887646"
+    }
+  }
+];
+
+// Summary statistics
+export const airdropStats = {
+  totalSubmissions: 29,
+  acceptedSubmissions: 19,
+  rejectedSubmissions: 10,
+  completionRate: "65.5%",
+  totalRewards: "3,100 TON",
+  eventStart: "2025-09-18",
+  eventEnd: "2025-10-14",
+  fastestProveTime: "131.14s", // AMD Ryzen 9 5950X
+  slowestProveTime: "4227.57s" // Intel Core i5-4310M
+};

--- a/hooks/useProofs.ts
+++ b/hooks/useProofs.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { staticAirdropProofs } from '@/data/staticProofData';
 
 export interface ProofSubmission {
   id: string;
@@ -31,25 +32,18 @@ export function useProofs(): UseProofsReturn {
 
   const fetchProofs = async () => {
     try {
-      console.log('🔄 Starting to fetch proofs...');
+      console.log('🔄 Loading static airdrop proof data...');
       setLoading(true);
       setError(null);
       
-      const response = await fetch('/api/proofs');
-      console.log('📡 API response status:', response.status);
+      // Simulate a small delay to show loading state
+      await new Promise(resolve => setTimeout(resolve, 500));
       
-      const data = await response.json();
-      console.log('📊 API response data:', data);
+      console.log('✅ Setting static proofs data:', staticAirdropProofs.length, 'items');
+      setProofs(staticAirdropProofs);
       
-      if (data.success) {
-        console.log('✅ Setting proofs data:', data.data.length, 'items');
-        setProofs(data.data);
-      } else {
-        console.log('❌ API returned error:', data.error);
-        setError(data.error || 'Failed to fetch proofs');
-      }
     } catch (err) {
-      console.error('❌ Fetch error:', err);
+      console.error('❌ Error loading static data:', err);
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {
       console.log('🏁 Setting loading to false');
@@ -60,10 +54,7 @@ export function useProofs(): UseProofsReturn {
   useEffect(() => {
     fetchProofs();
     
-    // Auto-refresh disabled to prevent loading indicators every 30 seconds
-    // Users can manually refresh if needed, or we can add a less intrusive update method
-    // const interval = setInterval(fetchProofs, 30000);
-    // return () => clearInterval(interval);
+    // No auto-refresh needed for static data
   }, []);
 
   return {

--- a/utils/text.ts
+++ b/utils/text.ts
@@ -22,35 +22,41 @@ export const trimText = (
 };
 
 /**
- * Format proving time from MM:SS:00 to "xx mins and xx secs"
- * @param {string} timeString - Time in MM:SS:00 format (where first part is minutes, second is seconds)
- * @returns {string} Formatted time string
+ * Format proving time from seconds (as string or number) to readable format
+ * @param {string | number} timeInput - Time in seconds (e.g., "455.535819" or 455.535819)
+ * @returns {string} Formatted time string (e.g., "7 mins 35 secs" or "1 hr 10 mins")
  */
-export const formatProvingTime = (timeString: string): string => {
-  if (!timeString || timeString === '00:00:00') {
+export const formatProvingTime = (timeInput: string | number): string => {
+  if (!timeInput || timeInput === '0' || timeInput === 0) {
+    return '0 secs';
+  }
+
+  // Convert to number and round to nearest second
+  const totalSeconds = Math.round(typeof timeInput === 'string' ? parseFloat(timeInput) : timeInput);
+  
+  if (isNaN(totalSeconds) || totalSeconds < 0) {
     return 'N/A';
   }
 
-  // Handle different time formats
-  const timeParts = timeString.split(':');
-  
-  if (timeParts.length === 3) {
-    // MM:SS:00 format (minutes:seconds:ignored)
-    const minutes = parseInt(timeParts[0]);
-    const seconds = parseInt(timeParts[1]);
-    // Third part is ignored (always 00)
-    
-    if (minutes === 0) {
-      return `${seconds} secs`;
-    } else if (seconds === 0) {
-      return `${minutes} mins`;
-    } else {
-      return `${minutes} mins and ${seconds} secs`;
+  // Calculate hours, minutes, and seconds
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  // Format based on duration
+  if (hours > 0) {
+    if (minutes > 0) {
+      return `${hours} hr ${minutes} mins`;
     }
+    return `${hours} hr`;
+  } else if (minutes > 0) {
+    if (seconds > 0) {
+      return `${minutes} mins ${seconds} secs`;
+    }
+    return `${minutes} mins`;
+  } else {
+    return `${seconds} secs`;
   }
-  
-  // If format is unexpected, return as-is
-  return timeString;
 };
 
 /**


### PR DESCRIPTION
- Update event dates to display submissions
- Switch from API to static data for proof submissions
- Add 29 real proof submissions (19 accepted, 10 rejected)
- Update prove time format to readable mins/secs format
- Shorten hardware info display for better UX